### PR TITLE
Generate artboards as PDF, not PNG.

### DIFF
--- a/UserFlows.sketchplugin/Contents/Sketch/common.js
+++ b/UserFlows.sketchplugin/Contents/Sketch/common.js
@@ -486,8 +486,8 @@ function flattenLayerToBitmap(layer, keepOriginal, scale) {
 		scale = (typeof scale !== 'undefined') ? scale : 1;
 	
 	var tempFolderPath = getTempFolderPath()
-	var filePath = tempFolderPath + "/temp.png";
-	exportLayerToPath(layer, filePath, scale)
+	var filePath = tempFolderPath + "/temp.pdf";
+	exportLayerToPath(layer, filePath, scale, "pdf")
 	
 	var bmp = addBitmap(filePath, parent, "Bitmap")
 	setPosition(bmp, layerRect.x, layerRect.y, true)


### PR DESCRIPTION
This is a small change for generating the art boards in the user flow as PDFs and not PNGs.